### PR TITLE
Occluders

### DIFF
--- a/tdw_physics/target_controllers/cloth_sagging.py
+++ b/tdw_physics/target_controllers/cloth_sagging.py
@@ -524,7 +524,8 @@ if __name__ == '__main__':
         occlusion_scale=args.occlusion_scale,
         remove_middle=args.remove_middle,
         use_ramp=bool(args.ramp),
-        ramp_color=args.rcolor
+        ramp_color=args.rcolor,
+        flex_only=args.only_use_flex_objects        
     )
 
     if bool(args.run):

--- a/tdw_physics/target_controllers/collision.py
+++ b/tdw_physics/target_controllers/collision.py
@@ -405,6 +405,7 @@ if __name__ == "__main__":
         occluder_categories=args.occluder_categories,
         num_occluders=args.num_occluders,
         occlusion_scale=args.occlusion_scale,
+        flex_only=args.only_use_flex_objects        
     )
 
     if bool(args.run):

--- a/tdw_physics/target_controllers/containment.py
+++ b/tdw_physics/target_controllers/containment.py
@@ -163,8 +163,8 @@ def get_containment_args(dataset_dir: str, parse=True):
 
     # camera
     parser.add_argument("--camera_distance",
-                        type=float,
-                        default=3.0,
+                        type=none_or_str,
+                        default="3.0",
                         help="radial distance from camera to centerpoint")
     parser.add_argument("--camera_min_angle",
                         type=float,

--- a/tdw_physics/target_controllers/containment.py
+++ b/tdw_physics/target_controllers/containment.py
@@ -688,7 +688,8 @@ if __name__ == "__main__":
         occlusion_scale=args.occlusion_scale,
         remove_middle=args.remove_middle,
         use_ramp=bool(args.ramp),
-        ramp_color=args.rcolor
+        ramp_color=args.rcolor,
+        flex_only=args.only_use_flex_objects        
     )
 
     if bool(args.run):

--- a/tdw_physics/target_controllers/containment.py
+++ b/tdw_physics/target_controllers/containment.py
@@ -285,7 +285,9 @@ class Containment(Tower):
 
         # base
         self.use_base = use_base
-        self._base_types = self.get_types(base_object) if self.use_base else self._target_types
+        self._base_types = self.get_types(
+            base_object, libraries=MODEL_LIBRARIES.keys(), flex_only=self.flex_only) \
+            if self.use_base else self._target_types
         self.base_scale_range = base_scale_range
         self.base_mass_range = base_mass_range
         self.base_color = base_color
@@ -293,7 +295,9 @@ class Containment(Tower):
 
         # attachment
         self.use_attachment = use_attachment        
-        self._attachment_types = self.get_types(attachment_object) if self.use_attachment else self._target_types
+        self._attachment_types = self.get_types(
+            attachment_object, libraries=MODEL_LIBRARIES.keys(), flex_only=self.flex_only) \
+            if self.use_attachment else self._target_types
         self.attachment_scale_range = attachment_scale_range
         self.attachment_color = attachment_color or self.middle_color
         self.attachment_mass_range = attachment_mass_range
@@ -612,6 +616,7 @@ if __name__ == "__main__":
     args = get_containment_args("containment")
 
     CC = Containment(
+        port=args.port,
         # contained
         contained_objects=args.middle,
         contained_scale_range=args.mscale,

--- a/tdw_physics/target_controllers/dominoes.py
+++ b/tdw_physics/target_controllers/dominoes.py
@@ -1348,26 +1348,24 @@ class Dominoes(RigidbodiesDataset):
                     o_id=o_id,
                     add_data=True))
 
-            # give it a texture if it's a primitive
+            # give it a color and texture if it's a primitive
+            # make sure it doesn't have the same color as the target object            
+            rgb = self.random_color(exclude=self.target_color, exclude_range=0.5)            
             if record.name in PRIMITIVE_NAMES:
                 commands.extend(
                     self.get_object_material_commands(
                         record, o_id, self.get_material_name(self.target_material)))
+                commands.append(
+                    {"$type": "set_color",
+                     "color": {"r": rgb[0], "g": rgb[1], "b": rgb[2], "a": 1.},
+                     "id": o_id})
 
-
-            # make sure it doesn't have the same color as the target object
-            rgb = self.random_color(exclude=self.target_color, exclude_range=0.5)
             scale = arr_to_xyz([1.,1.,1.])
             commands.extend([
-                {"$type": "set_color",
-                 "color": {"r": rgb[0], "g": rgb[1], "b": rgb[2], "a": 1.},
-                 "id": o_id},
                 {"$type": "scale_object",
                  "scale_factor": scale,
                  "id": o_id}
             ])
-
-            # todo: give it a random texture if it's a primitive
 
             # add the metadata
             self.colors = np.concatenate([self.colors, np.array(rgb).reshape((1,3))], axis=0)
@@ -1440,28 +1438,26 @@ class Dominoes(RigidbodiesDataset):
                     add_data=True))
 
             # give it a texture if it's a primitive
+            # make sure it doesn't have the same color as the target object            
+            rgb = self.random_color(exclude=self.target_color, exclude_range=0.5)            
             if record.name in PRIMITIVE_NAMES:
                 commands.extend(
                     self.get_object_material_commands(
                         record, o_id, self.get_material_name(self.target_material)))
-
-
-            # make sure it doesn't have the same color as the target object
-            rgb = self.random_color(exclude=self.target_color, exclude_range=0.5)
+                commands.append(
+                    {"$type": "set_color",
+                     "color": {"r": rgb[0], "g": rgb[1], "b": rgb[2], "a": 1.},
+                     "id": o_id})
 
             # do some trigonometry to figure out the scale of the occluder
             occ_dist = np.sqrt(pos['x']**2 + pos['z']**2)
             occ_dist *= np.cos(np.radians(theta))
             occ_target_height = self.camera_aim['y'] + occ_dist * np.tan(np.radians(self.camera_altitude))
             occ_target_height *= self.occlusion_scale
-
             scale_y = self.scale_to(o_height, occ_target_height)
             print("scale_y", scale_y)
             scale = arr_to_xyz([scale, scale_y, scale])
             commands.extend([
-                {"$type": "set_color",
-                 "color": {"r": rgb[0], "g": rgb[1], "b": rgb[2], "a": 1.},
-                 "id": o_id},
                 {"$type": "scale_object",
                  "scale_factor": scale,
                  "id": o_id}

--- a/tdw_physics/target_controllers/dominoes.py
+++ b/tdw_physics/target_controllers/dominoes.py
@@ -563,6 +563,7 @@ class Dominoes(RigidbodiesDataset):
 
 
     def get_types(self, objlist, libraries=["models_flex.json"], categories=None, flex_only=True):
+
         if isinstance(objlist, str):
             objlist = [objlist]
         recs = []

--- a/tdw_physics/target_controllers/dominoes.py
+++ b/tdw_physics/target_controllers/dominoes.py
@@ -16,20 +16,16 @@ from tdw_physics.rigidbodies_dataset import (RigidbodiesDataset,
                                              get_random_xyz_transform,
                                              get_range,
                                              handle_random_transform_args)
-from tdw_physics.util import (MODEL_LIBRARIES,
+from tdw_physics.util import (MODEL_LIBRARIES, FLEX_MODELS, MODEL_CATEGORIES,
+                              MATERIAL_TYPES, MATERIAL_NAMES,
                               get_parser,
                               xyz_to_arr, arr_to_xyz, str_to_xyz,
                               none_or_str, none_or_int, int_or_bool)
 
 from tdw_physics.postprocessing.labels import get_all_label_funcs
 
-
-MODEL_NAMES = [r.name for r in MODEL_LIBRARIES['models_flex.json'].records]
-M = MaterialLibrarian()
-MATERIAL_TYPES = M.get_material_types()
-MATERIAL_NAMES = {mtype: [m.name for m in M.get_all_materials_of_type(mtype)] \
-                  for mtype in MATERIAL_TYPES}
-ALL_NAMES = [r.name for r in MODEL_LIBRARIES['models_full.json'].records]
+PRIMITIVE_NAMES = [r.name for r in MODEL_LIBRARIES['models_flex.json'].records]
+FULL_NAMES = [r.name for r in MODEL_LIBRARIES['models_full.json'].records]
 
 def get_args(dataset_dir: str, parse=True):
     """
@@ -294,27 +290,27 @@ def get_args(dataset_dir: str, parse=True):
 
         if args.zone is not None:
             zone_list = args.zone.split(',')
-            assert all([t in MODEL_NAMES for t in zone_list]), \
-                "All target object names must be elements of %s" % MODEL_NAMES
+            assert all([t in PRIMITIVE_NAMES for t in zone_list]), \
+                "All target object names must be elements of %s" % PRIMITIVE_NAMES
             args.zone = zone_list
         else:
-            args.zone = MODEL_NAMES
+            args.zone = PRIMITIVE_NAMES
 
         if args.target is not None:
             targ_list = args.target.split(',')
-            assert all([t in MODEL_NAMES for t in targ_list]), \
-                "All target object names must be elements of %s" % MODEL_NAMES
+            assert all([t in PRIMITIVE_NAMES for t in targ_list]), \
+                "All target object names must be elements of %s" % PRIMITIVE_NAMES
             args.target = targ_list
         else:
-            args.target = MODEL_NAMES
+            args.target = PRIMITIVE_NAMES
 
         if args.probe is not None:
             probe_list = args.probe.split(',')
-            assert all([t in MODEL_NAMES for t in probe_list]), \
-                "All target object names must be elements of %s" % MODEL_NAMES
+            assert all([t in PRIMITIVE_NAMES for t in probe_list]), \
+                "All target object names must be elements of %s" % PRIMITIVE_NAMES
             args.probe = probe_list
         else:
-            args.probe = MODEL_NAMES
+            args.probe = PRIMITIVE_NAMES
 
         if args.middle is not None:
             middle_list = args.middle.split(',')
@@ -357,24 +353,24 @@ def get_args(dataset_dir: str, parse=True):
             args.material_types = matlist
 
         if args.distractor is None or args.distractor == 'full':
-            args.distractor = ALL_NAMES
+            args.distractor = FULL_NAMES
         elif args.distractor == 'core':
             args.distractor = [r.name for r in MODEL_LIBRARIES['models_core.json'].records]
         elif args.distractor in ['flex', 'primitives']:
-            args.distractor = MODEL_NAMES
+            args.distractor = PRIMITIVE_NAMES
         else:
             d_names = args.distractor.split(',')
-            args.distractor = [r for r in ALL_NAMES if any((nm in r for nm in d_names))]
+            args.distractor = [r for r in FULL_NAMES if any((nm in r for nm in d_names))]
 
         if args.occluder is None or args.occluder == 'full':
-            args.occluder = ALL_NAMES
+            args.occluder = FULL_NAMES
         elif args.occluder == 'core':
             args.occluder = [r.name for r in MODEL_LIBRARIES['models_core.json'].records]
         elif args.occluder in ['flex', 'primitives']:
-            args.occluder = MODEL_NAMES
+            args.occluder = PRIMITIVE_NAMES
         else:
             o_names = args.occluder.split(',')
-            args.occluder = [r for r in ALL_NAMES if any((nm in r for nm in o_names))]
+            args.occluder = [r for r in FULL_NAMES if any((nm in r for nm in o_names))]
 
         return args
 
@@ -414,8 +410,8 @@ class Dominoes(RigidbodiesDataset):
                  zone_location=None,
                  zone_scale_range=[0.5,0.01,0.5],
                  zone_friction=0.1,
-                 probe_objects=MODEL_NAMES,
-                 target_objects=MODEL_NAMES,
+                 probe_objects=PRIMITIVE_NAMES,
+                 target_objects=PRIMITIVE_NAMES,
                  probe_scale_range=[0.2, 0.3],
                  probe_mass_range=[2.,7.],
                  probe_color=None,
@@ -443,10 +439,10 @@ class Dominoes(RigidbodiesDataset):
                  probe_has_friction=False,
                  ramp_material=None,
                  zone_material=None,
-                 distractor_types=MODEL_NAMES,
+                 distractor_types=PRIMITIVE_NAMES,
                  distractor_categories=None,
                  num_distractors=0,
-                 occluder_types=MODEL_NAMES,
+                 occluder_types=PRIMITIVE_NAMES,
                  occluder_categories=None,
                  num_occluders=0,
                  occlusion_scale=0.6,
@@ -1335,7 +1331,7 @@ class Dominoes(RigidbodiesDataset):
                     add_data=True))
 
             # give it a texture if it's a primitive
-            if record.name in MODEL_NAMES:
+            if record.name in PRIMITIVE_NAMES:
                 commands.extend(
                     self.get_object_material_commands(
                         record, o_id, self.get_material_name(self.target_material)))
@@ -1426,7 +1422,7 @@ class Dominoes(RigidbodiesDataset):
                     add_data=True))
 
             # give it a texture if it's a primitive
-            if record.name in MODEL_NAMES:
+            if record.name in PRIMITIVE_NAMES:
                 commands.extend(
                     self.get_object_material_commands(
                         record, o_id, self.get_material_name(self.target_material)))

--- a/tdw_physics/target_controllers/drop.py
+++ b/tdw_physics/target_controllers/drop.py
@@ -519,7 +519,8 @@ if __name__ == "__main__":
         probe_material=args.pmaterial,
         zone_material=args.zmaterial,
         zone_color=args.zcolor,
-        zone_friction=args.zfriction,
+        zone_friction=args.zfriction,,
+        flex_only=args.only_use_flex_objects        
     )
 
     if bool(args.run):

--- a/tdw_physics/target_controllers/flex_dominoes.py
+++ b/tdw_physics/target_controllers/flex_dominoes.py
@@ -443,7 +443,8 @@ if __name__ == '__main__':
         occlusion_scale=args.occlusion_scale,
         remove_middle=args.remove_middle,
         use_ramp=bool(args.ramp),
-        ramp_color=args.rcolor
+        ramp_color=args.rcolor,
+        flex_only=args.only_use_flex_objects        
     )
 
     if bool(args.run):

--- a/tdw_physics/target_controllers/gravity.py
+++ b/tdw_physics/target_controllers/gravity.py
@@ -442,8 +442,8 @@ if __name__ == '__main__':
         remove_middle=args.remove_middle,
         use_ramp=bool(args.ramp),
         ramp_color=args.rcolor,
-        ramp_material=args.rmaterial
-
+        ramp_material=args.rmaterial,
+        flex_only=args.only_use_flex_objects
     )
 
 

--- a/tdw_physics/target_controllers/linking.py
+++ b/tdw_physics/target_controllers/linking.py
@@ -690,7 +690,8 @@ if __name__ == "__main__":
         remove_middle=args.remove_middle,
         use_ramp=bool(args.ramp),
         ramp_color=args.rcolor,
-        ramp_base_height_range=args.rheight                
+        ramp_base_height_range=args.rheight,
+        flex_only=args.only_use_flex_objects        
     )
 
     if bool(args.run):

--- a/tdw_physics/target_controllers/rolling_sliding.py
+++ b/tdw_physics/target_controllers/rolling_sliding.py
@@ -649,7 +649,8 @@ if __name__ == "__main__":
         num_occluders=args.num_occluders,
         occlusion_scale=args.occlusion_scale,
         ramp_scale=args.ramp_scale,
-        rolling_sliding_axis_length = args.rolling_sliding_axis_length
+        rolling_sliding_axis_length = args.rolling_sliding_axis_length,
+        flex_only=args.only_use_flex_objects        
     )
 
     if bool(args.run):

--- a/tdw_physics/target_controllers/towers.py
+++ b/tdw_physics/target_controllers/towers.py
@@ -554,7 +554,8 @@ if __name__ == "__main__":
         remove_middle=args.remove_middle,
         use_ramp=bool(args.ramp),
         ramp_color=args.rcolor,
-        ramp_base_height_range=args.rheight
+        ramp_base_height_range=args.rheight,
+        flex_only=args.only_use_flex_objects
     )
 
     if bool(args.run):

--- a/tdw_physics/util.py
+++ b/tdw_physics/util.py
@@ -144,6 +144,7 @@ def get_parser(dataset_dir: str, get_help: bool=False):
     parser.add_argument("--save_movies", action='store_true', help="Whether to write out MP4s of each trial")
     parser.add_argument("--save_labels", action='store_true', help="Whether to save out JSON labels for the full trial set.")
     parser.add_argument("--save_meshes", action='store_true', help="Whether to save meshes sent from the build")
+    
     return parser
 
 def get_args(dataset_dir: str):


### PR DESCRIPTION
Sample occluders and distractors from certain model names and categories.

Using the flag `--only_use_flex_objects` (defined in `dominoes.py`) the set of objects can be restricted to only those that are FLEX-enabled (and have readable meshes.) This flag defaults to False. To use it in controllers other than `dominoes.py`, you will have to pass the arg to the `Controller.__init__` method.

Finally, `tdw_physics/tdw_physics/util.py` is now a runnable script that's useful for looking up model names, flex-enabledness, material types, categories, and so on.

e.g.
```
python util.py --model_category "globe" --flex
```

will print all the flex-enabled globes in each model library.